### PR TITLE
Bugfix: Timout in Milliseconds, not Seconds

### DIFF
--- a/src/commands/http.h
+++ b/src/commands/http.h
@@ -222,7 +222,7 @@ class HTTPCommands {
         _serial.sendCMD("AT+HTTPDATA=", length, ",", 30);
 
         // timeout after 10 seconds
-        Response_t rsp = _serial.waitResponse("DOWNLOAD", 10, false, true);
+        Response_t rsp = _serial.waitResponse("DOWNLOAD", 10000, false, true);
 
         switch (rsp) {
             case Response_t::A76XX_RESPONSE_MATCH_1ST : {


### PR DESCRIPTION
Hey David!
Thanks for this nifty library. I'm currently using it with an A7670E and it is working fine in general, I really like how elegant the usage is!

However I wasn't able to successfully send POST requests, as the library always failed with a timeout error when setting the body of the request. Especially strange since it was working fine and without any delays when manually typing the AT commands. After some debugging I found out that the timeout (meant to be 10s) was given as 10, but needed to be 10000, as in `ModemSerial::waitResponse()` millis are used for the timeout.

So currently the timeout is actually 10ms, this is causing the constant timeouts i experienced.

Best Regards,
Anton